### PR TITLE
fix: moves the injection interface and symbol to separate file

### DIFF
--- a/src/some/some-module-api.provider.ts
+++ b/src/some/some-module-api.provider.ts
@@ -1,5 +1,5 @@
 import { Injectable, Inject } from "@nestjs/common";
-import { SomeModuleOptionsSymbol, SomeModuleOptions } from "./some-module.provider";
+import { SomeModuleOptionsSymbol, SomeModuleOptions } from "./some.constants";
 
 @Injectable()
 export class SomeModuleApi {

--- a/src/some/some-module.provider.ts
+++ b/src/some/some-module.provider.ts
@@ -1,17 +1,13 @@
 import { Injectable, Inject } from '@nestjs/common';
 import { SomeModuleApi } from './some-module-api.provider';
+import { SomeModuleOptions, SomeModuleOptionsSymbol } from './some.constants';
 
-export interface SomeModuleOptions {
-  apiEndpoint: string
-}
-
-export const SomeModuleOptionsSymbol = Symbol('SomeModuleOptions interface symbol for Nest DI')
 
 @Injectable()
-export class SomeModule {
+export class SomeModuleProvider {
   private readonly apiEndpoint: string
   constructor(
-    // private readonly api: SomeModuleApi, // uncomment this line for it to die horribly
+    private readonly api: SomeModuleApi, // uncomment this line for it to die horribly
     @Inject(SomeModuleOptionsSymbol) options: SomeModuleOptions,
   ) {
     console.log("Dependent provider works")

--- a/src/some/some.constants.ts
+++ b/src/some/some.constants.ts
@@ -1,0 +1,5 @@
+export interface SomeModuleOptions {
+  apiEndpoint: string
+}
+
+export const SomeModuleOptionsSymbol = Symbol('SomeModuleOptions interface symbol for Nest DI')

--- a/src/some/some.module.ts
+++ b/src/some/some.module.ts
@@ -1,5 +1,6 @@
 import { DynamicModule } from '@nestjs/common';
-import { SomeModuleOptions, SomeModuleOptionsSymbol } from './some-module.provider';
+import { SomeModuleProvider } from './some-module.provider';
+import { SomeModuleOptions, SomeModuleOptionsSymbol } from './some.constants';
 import { SomeModuleApi } from './some-module-api.provider';
 
 export class SomeModule {
@@ -13,7 +14,7 @@ export class SomeModule {
           useValue: options,
         },
         SomeModuleApi,
-        SomeModule,
+        SomeModuleProvider,
       ]
     }
   }


### PR DESCRIPTION
While Nest warns about classes and modules being circular, and not files explicitly, think about the fact that to instantiate `SomeMoudleApi` we need to import the `some-module.provider.ts` file, which would then import the `some-module-api.provider.ts` file, which you can see becomes circular pretty quickly. Constants should almost always go in their own files.